### PR TITLE
Create Keycloak Instance with Nginx Reverse Proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,57 @@
-# keycloak-Instance
-keycloak-Instance
+# Keycloak Instance
+
+This repository contains a Docker-based setup for running a Keycloak instance with Nginx as a reverse proxy. This setup is intended for local development and testing purposes.
+
+## Prerequisites
+
+- Docker
+- Docker Compose
+
+## Setup Instructions
+
+1. **Clone the Repository:**
+
+   ```bash
+   git clone https://github.com/BetterGR/keycloak-instance.git
+   cd keycloak-instance
+   ```
+
+2. **Modify the Hosts File:**
+
+   Add the following line to your hosts file to map `auth.BetterGR.org` to `localhost`:
+
+   - On Windows: `C:\Windows\System32\drivers\etc\hosts`
+   - On Linux/macOS: `/etc/hosts`
+   ```
+   127.0.0.1 auth.BetterGR.org   ```
+
+3. **Start the Services:**
+
+   Use Docker Compose to start the Keycloak and Nginx services:
+   ```bash
+   docker-compose up   ```
+
+4. **Access Keycloak:**
+
+   Open your web browser and navigate to `http://auth.BetterGR.org`. Log in using the default admin credentials:
+
+   - Username: `admin`
+   - Password: `admin`
+
+## Configuration
+
+- **Keycloak Configuration:**
+  - The Keycloak service is configured to run in development mode with default admin credentials. You can modify these in the `docker-compose.yml` file.
+
+- **Nginx Configuration:**
+  - The Nginx configuration is located in `ngnix/ngnix.conf`. It is set up to forward requests from `auth.BetterGR.org` to the Keycloak service.
+
+## Troubleshooting
+
+- Ensure Docker and Docker Compose are installed and running.
+- Verify that the `ngnix.conf` file is correctly placed and accessible.
+- Check that the hosts file is correctly configured.
+
+## License
+
+This project is licensed under the Apache License 2.0. See the [LICENSE](LICENSE) file for details.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  keycloak:
+    image: quay.io/keycloak/keycloak:latest
+    ports:
+      - "8080:8080"
+    environment:
+      - KEYCLOAK_ADMIN=admin
+      - KEYCLOAK_ADMIN_PASSWORD=admin
+    command: start-dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,3 +7,12 @@ services:
       - KEYCLOAK_ADMIN=admin
       - KEYCLOAK_ADMIN_PASSWORD=admin
     command: start-dev
+
+  nginx:
+    image: nginx:latest
+    ports:
+      - "80:80"
+    volumes:
+      - ./ngnix/ngnix.conf:/etc/nginx/conf.d/default.conf
+    depends_on:
+      - keycloak

--- a/ngnix/ngnix.conf
+++ b/ngnix/ngnix.conf
@@ -1,0 +1,12 @@
+server {
+    listen 80;
+    server_name auth.BetterGR.org;
+
+    location / {
+        proxy_pass http://keycloak:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}


### PR DESCRIPTION
## Summary

This pull request sets up a Keycloak instance using Docker and configures Nginx as a reverse proxy to facilitate local development and testing.

## Changes

- **Keycloak Instance:**
  - Created a Docker-based Keycloak instance configured for development use.
  - Set up default admin credentials for easy access and testing.

- **Nginx Configuration:**
  - Added a new `ngnix` directory containing `ngnix.conf` to configure Nginx as a reverse proxy.
  - Configured Nginx to forward requests from `auth.BetterGR.org` to the Keycloak service.

- **Documentation:**
  - Updated `README.md` with setup instructions, including how to modify the hosts file and start the services using Docker Compose.
